### PR TITLE
Wrap reader errors with :read-source error phase

### DIFF
--- a/src/replete/repl.cljs
+++ b/src/replete/repl.cljs
@@ -66,7 +66,10 @@
   (= "iPad" (:user-interface-idiom @app-env)))
 
 (defn repl-read-string [line]
-  (r/read-string {:read-cond :allow :features #{:cljs}} line))
+  (try
+    (r/read-string {:read-cond :allow :features #{:cljs}} line)
+    (catch :default e
+      (throw (ex-info nil {:clojure.error/phase :read-source} e)))))
 
 (def ^:private expression-name "Expression")
 (def ^:private could-not-eval-expr (str "Could not eval " expression-name))


### PR DESCRIPTION
Fixes case where reader errors occur (for example
when reading 08) and the exception printed should
indicate a synax error as opposed to an execution
error.