### PR TITLE
Abbreviate var and keywords when printing

### DIFF
--- a/src/replete/repl.cljs
+++ b/src/replete/repl.cljs
@@ -703,7 +703,8 @@
                  (if-not error
                    (do
                      (let [out-str (with-out-str (pprint/pprint value {:width (or (:width @app-env)
-                                                                                  35)}))
+                                                                                  35)
+                                                                       :ns    ns}))
                            out-str (subs out-str 0 (dec (count out-str)))]
                        (print out-str))
                      (process-1-2-3 expression-form value)


### PR DESCRIPTION
Simplify the printing of vars and keywords, abbreviating them relative to the current namespace.

This makes things more readily fit on mobile screens, and is simpler for new users who haven't yet been exposed to the concept of namespaces.

So for example, a def of a var prints in a simpler way:

```
(defn square [x]
 (* x x))
#'square
```

Likewise, if you evaluate, say `::foo`, you will see `::foo` printed.

This PR also handles the same idea in namespace maps, 

```
{::foo 1 ::bar 2 ::baz {::quux 3}}
```

prints as

```
#::{:foo 1, :bar 2, :baz #::{:quux 3}}
```

instead of the more verbose

```
#:cljs.user{:foo 1, :bar 2, :baz #:cljs.user{:quux 3}}
```