### PR TITLE
Update Andare to 0.10.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:deps    {andare                     {:mvn/version "0.9.0"}
+{:deps    {andare                     {:mvn/version "0.10.0"}
            chivorcam                  {:mvn/version "1.0.0"}
            cljsjs/parinfer            {:mvn/version "3.11.0-0"}
            com.cognitect/transit-cljs {:mvn/version "0.8.248"}


### PR DESCRIPTION
Note that downstream projects have a macros build script that refers to the JAR version number which would also need to be updated.