### PR TITLE
Update to test.check 0.10.0-alpha4

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,5 +6,5 @@
            tailrecursion/cljson       {:mvn/version "1.0.7"}
            malabarba/lazy-map         {:mvn/version "1.3"}
            org.clojure/clojurescript  {:mvn/version "1.10.520"}
-           org.clojure/test.check     {:mvn/version "0.10.0-alpha3"}}
+           org.clojure/test.check     {:mvn/version "0.10.0-alpha4"}}
  :aliases {:cljs-repl {:main-opts ["-m" "cljs.main" "-d" "out" "-re" "node" "-r"]}}}


### PR DESCRIPTION
Note that downstream projects have a reference to this version number in the build script (macros compilation) that would need to be updated.