### PR TITLE
:bug: return the catch-all error as a vector with one map rather than…

### DIFF
--- a/src/replete/prepl.cljs
+++ b/src/replete/prepl.cljs
@@ -238,6 +238,6 @@
                                                        :val                 (string-error error)}))))))
                @eval-result)))
          (catch :default e
-           (vec (merge result {:tag                 :err
-                               :clojure.error/phase :read-source
-                               :val                 (string-error e)}))))))))
+           [(merge result {:tag                 :err
+                           :clojure.error/phase :read-source
+                           :val                 (string-error e)})]))))))


### PR DESCRIPTION
… a vector of vectors

https://github.com/replete-repl/replete-shared/issues/35